### PR TITLE
feat: add compatibility API observability

### DIFF
--- a/backend/app/controller/admin/auth.go
+++ b/backend/app/controller/admin/auth.go
@@ -114,8 +114,10 @@ func (c *AuthController) GetAuthOidcToken() mvc.Result {
 	ticket := c.Ctx.URLParamDefault("ticket", "")
 	token, err := service.ExchangeAdminTicket(ticket)
 	if err != nil {
+		c.recordAdminSecurityAudit("admin_oidc_token_exchange", false, err.Error())
 		return c.Error(nil, err.Error())
 	}
+	c.recordAdminSecurityAudit("admin_oidc_token_exchange", true, "token")
 	return c.Success(iris.Map{
 		"token": token,
 	}, "ok")
@@ -128,10 +130,12 @@ func (c *AuthController) GetAuthOidcCallback() mvc.Result {
 
 	ticket, redirectTo, err := service.ConsumeAdminCallback(code, state)
 	if err != nil {
+		c.recordAdminSecurityAudit("admin_oidc_callback", false, err.Error())
 		c.Ctx.Redirect(withQuery(redirectTo, "oidc_error", err.Error()), iris.StatusFound)
 		return mvc.Response{}
 	}
 
+	c.recordAdminSecurityAudit("admin_oidc_callback", true, "ticket")
 	target := withQuery(redirectTo, "oidc_ticket", ticket)
 	c.Ctx.Redirect(target, iris.StatusFound)
 	return mvc.Response{}
@@ -161,8 +165,10 @@ func (c *AuthController) GetAuthOauthToken() mvc.Result {
 	ticket := c.Ctx.URLParamDefault("ticket", "")
 	token, err := service.ExchangeAdminTicket(ticket)
 	if err != nil {
+		c.recordAdminSecurityAudit("admin_oauth_token_exchange", false, err.Error())
 		return c.Error(nil, err.Error())
 	}
+	c.recordAdminSecurityAudit("admin_oauth_token_exchange", true, "token")
 	return c.Success(iris.Map{
 		"token": token,
 	}, "ok")
@@ -176,10 +182,12 @@ func (c *AuthController) HandleOauthCallback() mvc.Result {
 
 	ticket, redirectTo, err := service.ConsumeAdminCallback(provider, code, state)
 	if err != nil {
+		c.recordAdminSecurityAudit("admin_oauth_callback", false, provider+": "+err.Error())
 		c.Ctx.Redirect(withQuery(redirectTo, "oauth_error", err.Error()), iris.StatusFound)
 		return mvc.Response{}
 	}
 
+	c.recordAdminSecurityAudit("admin_oauth_callback", true, provider+": ticket")
 	target := withQuery(withQuery(redirectTo, "oauth_provider", provider), "oauth_ticket", ticket)
 	c.Ctx.Redirect(target, iris.StatusFound)
 	return mvc.Response{}
@@ -206,6 +214,16 @@ func (c *AuthController) recordAdminLoginAudit(userID int, username string, succ
 		UserID:    userID,
 		Username:  username,
 		Event:     "admin_login",
+		IP:        c.Ctx.RemoteAddr(),
+		UserAgent: c.Ctx.GetHeader("User-Agent"),
+		Success:   success,
+		Reason:    reason,
+	})
+}
+
+func (c *AuthController) recordAdminSecurityAudit(event string, success bool, reason string) {
+	_ = c.auditService().CreateSecurityAudit(core.SecurityAuditCreateCommand{
+		Event:     event,
 		IP:        c.Ctx.RemoteAddr(),
 		UserAgent: c.Ctx.GetHeader("User-Agent"),
 		Success:   success,

--- a/backend/app/controller/admin/auth.go
+++ b/backend/app/controller/admin/auth.go
@@ -6,6 +6,7 @@ import (
 	"rustdesk-api-server-pro/app/model"
 	"rustdesk-api-server-pro/config"
 	"rustdesk-api-server-pro/helper/captcha"
+	"rustdesk-api-server-pro/internal/core"
 	v2service "rustdesk-api-server-pro/internal/service"
 	"rustdesk-api-server-pro/util"
 	"strconv"
@@ -32,24 +33,29 @@ func (c *AuthController) PostAuthLogin() mvc.Result {
 	var loginForm admin.LoginForm
 	err := c.Ctx.ReadJSON(&loginForm)
 	if err != nil {
+		c.recordAdminLoginAudit(0, "", false, "decode_error: "+err.Error())
 		return c.Error(nil, err.Error())
 	}
 
 	if !captcha.VerifyCode(loginForm.CaptchaId, loginForm.Code) {
+		c.recordAdminLoginAudit(0, loginForm.Username, false, "CaptchaError")
 		return c.Error(nil, "CaptchaError")
 	}
 
 	var user model.User
 	get, err := c.Db.Where("username = ? and is_admin = 1", loginForm.Username).Get(&user)
 	if err != nil {
+		c.recordAdminLoginAudit(0, loginForm.Username, false, err.Error())
 		return c.Error(nil, err.Error())
 	}
 
 	if !get {
+		c.recordAdminLoginAudit(0, loginForm.Username, false, "UserNotExists")
 		return c.Error(nil, "UserNotExists")
 	}
 
 	if !util.PasswordVerify(loginForm.Password, user.Password) {
+		c.recordAdminLoginAudit(user.Id, loginForm.Username, false, "UsernameOrPasswordError")
 		return c.Error(nil, "UsernameOrPasswordError")
 	}
 
@@ -72,9 +78,11 @@ func (c *AuthController) PostAuthLogin() mvc.Result {
 
 	_, err = c.Db.Insert(authToken)
 	if err != nil {
+		c.recordAdminLoginAudit(user.Id, loginForm.Username, false, err.Error())
 		return c.Error(nil, err.Error())
 	}
 
+	c.recordAdminLoginAudit(user.Id, loginForm.Username, true, "token")
 	return c.Success(iris.Map{
 		"token": token,
 	}, "ok")
@@ -191,6 +199,18 @@ func (c *AuthController) currentBaseURL() string {
 		host = c.Ctx.Host()
 	}
 	return scheme + "://" + host
+}
+
+func (c *AuthController) recordAdminLoginAudit(userID int, username string, success bool, reason string) {
+	_ = c.auditService().CreateSecurityAudit(core.SecurityAuditCreateCommand{
+		UserID:    userID,
+		Username:  username,
+		Event:     "admin_login",
+		IP:        c.Ctx.RemoteAddr(),
+		UserAgent: c.Ctx.GetHeader("User-Agent"),
+		Success:   success,
+		Reason:    reason,
+	})
 }
 
 func withQuery(target, key, value string) string {

--- a/backend/app/controller/admin/basic.go
+++ b/backend/app/controller/admin/basic.go
@@ -3,6 +3,8 @@ package admin
 import (
 	"rustdesk-api-server-pro/app/model"
 	"rustdesk-api-server-pro/config"
+	"rustdesk-api-server-pro/internal/repository"
+	v2service "rustdesk-api-server-pro/internal/service"
 
 	"github.com/kataras/iris/v12"
 	"github.com/kataras/iris/v12/mvc"
@@ -24,6 +26,10 @@ func (c *basicController) GetToken() string {
 
 func (c *basicController) GetAuthToken() *model.AuthToken {
 	return c.Ctx.Values().Get(config.AdminAuthToken).(*model.AuthToken)
+}
+
+func (c *basicController) auditService() *v2service.AuditService {
+	return v2service.NewAuditService(repository.NewXormAuditRepository(c.Db))
 }
 
 func (c *basicController) Success(data interface{}, message string) mvc.Result {

--- a/backend/app/controller/admin/users.go
+++ b/backend/app/controller/admin/users.go
@@ -251,10 +251,12 @@ func (c *UsersController) HandleDelete() mvc.Result {
 		return c.Error(nil, err.Error())
 	}
 	ids := util.RemoveElement(params.Ids, 1)
-	beforeUsers := make([]model.User, 0)
-	if len(ids) > 0 {
-		_ = c.Db.In("id", ids).Find(&beforeUsers)
+	if len(ids) == 0 {
+		c.recordUserOperationAudit("admin_user_delete", "", nil, iris.Map{"ids": params.Ids}, "failure", "NoUserIds")
+		return c.Error(nil, "NoUserIds")
 	}
+	beforeUsers := make([]model.User, 0)
+	_ = c.Db.In("id", ids).Find(&beforeUsers)
 	beforeAudit := make([]iris.Map, 0)
 	for _, u := range beforeUsers {
 		user := u

--- a/backend/app/controller/admin/users.go
+++ b/backend/app/controller/admin/users.go
@@ -359,10 +359,7 @@ func auditJSON(value interface{}) string {
 	return string(data)
 }
 
-func auditIDsResource(ids []int) string {
-	if len(ids) == 0 {
-		return ""
-	}
+func auditIDsResource(ids interface{}) string {
 	data, err := json.Marshal(ids)
 	if err != nil {
 		return ""

--- a/backend/app/controller/admin/users.go
+++ b/backend/app/controller/admin/users.go
@@ -1,11 +1,14 @@
 package admin
 
 import (
+	"encoding/json"
 	"rustdesk-api-server-pro/app/form/admin"
 	"rustdesk-api-server-pro/app/model"
 	"rustdesk-api-server-pro/config"
 	"rustdesk-api-server-pro/db"
+	"rustdesk-api-server-pro/internal/core"
 	"rustdesk-api-server-pro/util"
+	"strconv"
 
 	"github.com/kataras/iris/v12"
 	"github.com/kataras/iris/v12/mvc"
@@ -96,18 +99,21 @@ func (c *UsersController) HandleAdd() mvc.Result {
 	var form admin.UserForm
 	err := c.Ctx.ReadJSON(&form)
 	if err != nil {
+		c.recordUserOperationAudit("admin_user_add", "", nil, sanitizeUserFormForAudit(form), "failure", err.Error())
 		return c.Error(nil, err.Error())
 	}
 
 	if form.Username == "" {
+		c.recordUserOperationAudit("admin_user_add", "", nil, sanitizeUserFormForAudit(form), "failure", "UsernameEmpty")
 		return c.Error(nil, "UsernameEmpty")
 	}
-	has, _ := c.Db.Where("username = ?", form.Username).Get(&model.User{})
-	if has {
+	if has, _ := c.Db.Where("username = ?", form.Username).Get(&model.User{}); has {
+		c.recordUserOperationAudit("admin_user_add", form.Username, nil, sanitizeUserFormForAudit(form), "failure", "UserExists")
 		return c.Error(nil, "UserExists")
 	}
 
 	if form.Password == "" {
+		c.recordUserOperationAudit("admin_user_add", form.Username, nil, sanitizeUserFormForAudit(form), "failure", "PasswordEmpty")
 		return c.Error(nil, "PasswordEmpty")
 	}
 
@@ -121,6 +127,7 @@ func (c *UsersController) HandleAdd() mvc.Result {
 
 	p, err := util.Password(form.Password)
 	if err != nil {
+		c.recordUserOperationAudit("admin_user_add", form.Username, nil, sanitizeUserFormForAudit(form), "failure", err.Error())
 		return c.Error(nil, err.Error())
 	}
 
@@ -139,6 +146,7 @@ func (c *UsersController) HandleAdd() mvc.Result {
 	// 要绑定2fa
 	if form.LoginVerify == model.LOGIN_TFA_CHECK {
 		if !totp.Validate(form.TwoFactorAuthCode, form.TwoFactorAuthSecret) {
+			c.recordUserOperationAudit("admin_user_add", form.Username, nil, sanitizeUserFormForAudit(form), "failure", "TFA_Validate_Err")
 			return c.Error(nil, "TFA_Validate_Err")
 		}
 		user.TwoFactorAuthSecret = form.TwoFactorAuthSecret
@@ -146,9 +154,12 @@ func (c *UsersController) HandleAdd() mvc.Result {
 
 	_, err = c.Db.Insert(user)
 	if err != nil {
+		c.recordUserOperationAudit("admin_user_add", form.Username, nil, sanitizeUserFormForAudit(form), "failure", err.Error())
 		return c.Error(nil, err.Error())
 	}
 
+	resourceID := strconv.Itoa(user.Id)
+	c.recordUserOperationAudit("admin_user_add", resourceID, nil, sanitizeUserForAudit(user), "success", "")
 	return c.Success(nil, "UserAddSuccess")
 }
 
@@ -156,10 +167,12 @@ func (c *UsersController) HandleEdit() mvc.Result {
 	var form admin.UserForm
 	err := c.Ctx.ReadJSON(&form)
 	if err != nil {
+		c.recordUserOperationAudit("admin_user_edit", "", nil, sanitizeUserFormForAudit(form), "failure", err.Error())
 		return c.Error(nil, err.Error())
 	}
 
 	if form.Id <= 0 {
+		c.recordUserOperationAudit("admin_user_edit", "", nil, sanitizeUserFormForAudit(form), "failure", "DataError")
 		return c.Error(nil, "DataError")
 	}
 
@@ -171,6 +184,7 @@ func (c *UsersController) HandleEdit() mvc.Result {
 	if form.Password != "" {
 		p, err = util.Password(form.Password)
 		if err != nil {
+			c.recordUserOperationAudit("admin_user_edit", strconv.Itoa(form.Id), nil, sanitizeUserFormForAudit(form), "failure", err.Error())
 			return c.Error(nil, err.Error())
 		}
 	}
@@ -194,14 +208,21 @@ func (c *UsersController) HandleEdit() mvc.Result {
 	}
 
 	var user model.User
-	_, err = c.Db.Where("id = ?", form.Id).Get(&user)
+	has, err := c.Db.Where("id = ?", form.Id).Get(&user)
 	if err != nil {
+		c.recordUserOperationAudit("admin_user_edit", strconv.Itoa(form.Id), nil, sanitizeUserFormForAudit(form), "failure", err.Error())
 		return c.Error(nil, err.Error())
 	}
+	if !has {
+		c.recordUserOperationAudit("admin_user_edit", strconv.Itoa(form.Id), nil, sanitizeUserFormForAudit(form), "failure", "UserNotExists")
+		return c.Error(nil, "UserNotExists")
+	}
+	beforeAudit := sanitizeUserForAudit(&user)
 
 	// 要绑定2fa
 	if form.LoginVerify == model.LOGIN_TFA_CHECK && form.TwoFactorAuthSecret != user.TwoFactorAuthSecret {
 		if !totp.Validate(form.TwoFactorAuthCode, form.TwoFactorAuthSecret) {
+			c.recordUserOperationAudit("admin_user_edit", strconv.Itoa(form.Id), beforeAudit, sanitizeUserFormForAudit(form), "failure", "TFA_Validate_Err")
 			return c.Error(nil, "TFA_Validate_Err")
 		}
 		newUser.TwoFactorAuthSecret = form.TwoFactorAuthSecret
@@ -209,9 +230,13 @@ func (c *UsersController) HandleEdit() mvc.Result {
 
 	_, err = c.Db.Where("id = ?", form.Id).MustCols("licensed_devices", "status", "is_admin").Update(newUser)
 	if err != nil {
+		c.recordUserOperationAudit("admin_user_edit", strconv.Itoa(form.Id), beforeAudit, sanitizeUserFormForAudit(form), "failure", err.Error())
 		return c.Error(nil, err.Error())
 	}
 
+	var updated model.User
+	_, _ = c.Db.Where("id = ?", form.Id).Get(&updated)
+	c.recordUserOperationAudit("admin_user_edit", strconv.Itoa(form.Id), beforeAudit, sanitizeUserForAudit(&updated), "success", "")
 	return c.Success(nil, "UserUpdateSuccess")
 }
 
@@ -222,13 +247,26 @@ func (c *UsersController) HandleDelete() mvc.Result {
 	var params deleteParams
 	err := c.Ctx.ReadJSON(&params)
 	if err != nil {
+		c.recordUserOperationAudit("admin_user_delete", "", nil, iris.Map{"ids": params.Ids}, "failure", err.Error())
 		return c.Error(nil, err.Error())
 	}
 	ids := util.RemoveElement(params.Ids, 1)
+	beforeUsers := make([]model.User, 0)
+	if len(ids) > 0 {
+		_ = c.Db.In("id", ids).Find(&beforeUsers)
+	}
+	beforeAudit := make([]iris.Map, 0)
+	for _, u := range beforeUsers {
+		user := u
+		beforeAudit = append(beforeAudit, sanitizeUserForAudit(&user))
+	}
+
 	_, err = c.Db.In("id", ids).Delete(&model.User{})
 	if err != nil {
+		c.recordUserOperationAudit("admin_user_delete", auditIDsResource(ids), beforeAudit, iris.Map{"ids": ids}, "failure", err.Error())
 		return c.Error(nil, err.Error())
 	}
+	c.recordUserOperationAudit("admin_user_delete", auditIDsResource(ids), beforeAudit, iris.Map{"ids": ids}, "success", "")
 	return c.Success(nil, "UserDeleteSuccess")
 }
 
@@ -252,4 +290,80 @@ func (c *UsersController) HandleTOTP() mvc.Result {
 		"url": key.String(),
 		"key": key.Secret(),
 	}, "ok")
+}
+
+func (c *UsersController) recordUserOperationAudit(action string, resourceID string, beforeData interface{}, afterData interface{}, result string, errorMessage string) {
+	actor := c.GetUser()
+	cmd := core.OperationAuditCreateCommand{
+		Action:       action,
+		ResourceType: "user",
+		ResourceID:   resourceID,
+		BeforeData:   auditJSON(beforeData),
+		AfterData:    auditJSON(afterData),
+		IP:           c.Ctx.RemoteAddr(),
+		UserAgent:    c.Ctx.GetHeader("User-Agent"),
+		Result:       result,
+		ErrorMessage: errorMessage,
+	}
+	if actor != nil {
+		cmd.ActorUserID = actor.Id
+		cmd.ActorUsername = actor.Username
+	}
+	_ = c.auditService().CreateOperationAudit(cmd)
+}
+
+func sanitizeUserForAudit(user *model.User) iris.Map {
+	if user == nil {
+		return nil
+	}
+	return iris.Map{
+		"id":               user.Id,
+		"username":         user.Username,
+		"name":             user.Name,
+		"email":            user.Email,
+		"licensed_devices": user.LicensedDevices,
+		"note":             user.Note,
+		"login_verify":     user.LoginVerify,
+		"status":           user.Status,
+		"is_admin":         user.IsAdmin,
+		"has_2fa":          user.TwoFactorAuthSecret != "",
+	}
+}
+
+func sanitizeUserFormForAudit(form admin.UserForm) iris.Map {
+	return iris.Map{
+		"id":               form.Id,
+		"username":         form.Username,
+		"name":             form.Name,
+		"email":            form.Email,
+		"licensed_devices": form.LicensedDevices,
+		"note":             form.Note,
+		"login_verify":     form.LoginVerify,
+		"status":           form.Status,
+		"is_admin":         form.IsAdmin,
+		"password_changed":  form.Password != "",
+		"has_2fa_secret":   form.TwoFactorAuthSecret != "",
+	}
+}
+
+func auditJSON(value interface{}) string {
+	if value == nil {
+		return ""
+	}
+	data, err := json.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func auditIDsResource(ids []int) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	data, err := json.Marshal(ids)
+	if err != nil {
+		return ""
+	}
+	return string(data)
 }

--- a/backend/app/controller/api/compat_audit.go
+++ b/backend/app/controller/api/compat_audit.go
@@ -1,0 +1,54 @@
+package api
+
+import "rustdesk-api-server-pro/internal/core"
+
+func (c *basicController) recordCompatAPIAudit(isStub bool, statusCode int, result string, errorMessage string, body []byte) {
+	if c == nil || c.Db == nil || c.Ctx == nil {
+		return
+	}
+	if statusCode == 0 {
+		statusCode = 200
+	}
+	if result == "" {
+		result = "ok"
+	}
+
+	path := c.Ctx.Path()
+	if path == "" && c.Ctx.Request() != nil && c.Ctx.Request().URL != nil {
+		path = c.Ctx.Request().URL.Path
+	}
+
+	_ = c.auditService().CreateCompatAPIAudit(core.CompatAPIAuditCreateCommand{
+		Method:        c.Ctx.Method(),
+		Path:          path,
+		ClientVersion: firstNonEmptyString(c.Ctx.GetHeader("X-RustDesk-Version"), c.Ctx.GetHeader("RustDesk-Version"), c.Ctx.GetHeader("X-Client-Version"), c.Ctx.GetHeader("Client-Version")),
+		RustdeskID:    compatRustdeskID(c, body),
+		IsStub:        isStub,
+		StatusCode:    statusCode,
+		IP:            c.Ctx.RemoteAddr(),
+		UserAgent:     c.Ctx.GetHeader("User-Agent"),
+		Result:        result,
+		ErrorMessage:  errorMessage,
+	})
+}
+
+func compatRustdeskID(c *basicController, body []byte) string {
+	if c != nil && c.Ctx != nil {
+		if id := firstNonEmptyString(c.Ctx.URLParam("id"), c.Ctx.URLParam("rustdesk_id"), c.Ctx.URLParam("rustdeskId")); id != "" {
+			return id
+		}
+	}
+	if len(body) == 0 {
+		return ""
+	}
+	return firstJSONValue(body, "id", "rustdesk_id", "rustdeskId")
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/backend/app/controller/api/compat_lic.go
+++ b/backend/app/controller/api/compat_lic.go
@@ -1,6 +1,10 @@
 package api
 
-import "github.com/kataras/iris/v12/mvc"
+import (
+	"encoding/json"
+
+	"github.com/kataras/iris/v12/mvc"
+)
 
 // CompatLicController provides compatibility endpoints under /lic/web/api used by newer clients/plugins.
 // This project does not implement the official plugin signing service, but returns a stable JSON shape
@@ -24,14 +28,21 @@ func (c *CompatLicController) BeforeActivation(b mvc.BeforeActivation) {
 }
 
 func (c *CompatLicController) HandlePluginSign() mvc.Result {
+	body, err := c.readBodyBytes()
+	if err != nil {
+		c.recordCompatAPIAudit(true, 400, "error", err.Error(), nil)
+		return mvc.Response{Object: pluginSignResp{SignedMsg: []byte{}}}
+	}
+
 	var req pluginSignReq
 	// Always return the expected JSON shape even when payload is invalid, so client plugins do not fail on decode.
-	if err := c.readJSONBody(&req); err != nil {
-		return mvc.Response{
-			Object: pluginSignResp{SignedMsg: []byte{}},
-		}
+	if err := json.Unmarshal(body, &req); err != nil {
+		c.recordCompatAPIAudit(true, 400, "decode_error", err.Error(), body)
+		return mvc.Response{Object: pluginSignResp{SignedMsg: []byte{}}}
 	}
+
 	result := c.compatService().PluginSign(req.Msg)
+	c.recordCompatAPIAudit(true, 200, "passthrough", "", body)
 	return mvc.Response{
 		Object: pluginSignResp{SignedMsg: result.SignedMsg},
 	}

--- a/backend/app/controller/api/compat_public.go
+++ b/backend/app/controller/api/compat_public.go
@@ -65,6 +65,7 @@ func (c *CompatPublicController) BeforeActivation(b mvc.BeforeActivation) {
 }
 
 func (c *CompatPublicController) HandleHealth() mvc.Result {
+	c.recordCompatAPIAudit(false, 200, "ok", "", nil)
 	return mvc.Response{Object: iris.Map{
 		"ok":      true,
 		"status":  "ok",
@@ -73,6 +74,7 @@ func (c *CompatPublicController) HandleHealth() mvc.Result {
 }
 
 func (c *CompatPublicController) HandleStatus() mvc.Result {
+	c.recordCompatAPIAudit(false, 200, "ok", "", nil)
 	return mvc.Response{Object: iris.Map{
 		"ok":            true,
 		"status":        "ok",
@@ -83,6 +85,7 @@ func (c *CompatPublicController) HandleStatus() mvc.Result {
 }
 
 func (c *CompatPublicController) HandleVersion() mvc.Result {
+	c.recordCompatAPIAudit(false, 200, "ok", "", nil)
 	return mvc.Response{Object: iris.Map{
 		"version":       service.CompatSysinfoVersion,
 		"server":        "rustdesk-api-server-pro",
@@ -91,10 +94,12 @@ func (c *CompatPublicController) HandleVersion() mvc.Result {
 }
 
 func (c *CompatPublicController) HandleCompatTarget() mvc.Result {
+	c.recordCompatAPIAudit(false, 200, "ok", "", nil)
 	return mvc.Response{Object: c.compatService().Target()}
 }
 
 func (c *CompatPublicController) HandleFeatures() mvc.Result {
+	c.recordCompatAPIAudit(false, 200, "ok", "", nil)
 	return mvc.Response{Object: iris.Map{
 		"address_book":           true,
 		"audit":                  true,
@@ -105,11 +110,13 @@ func (c *CompatPublicController) HandleFeatures() mvc.Result {
 		"strategy":               true,
 		"record":                 true,
 		"plugin_sign_passthrough": true,
+		"compat_api_audit":       true,
 		"compat_target":          c.compatService().Target(),
 	}}
 }
 
 func (c *CompatPublicController) HandleClientConfig() mvc.Result {
+	c.recordCompatAPIAudit(false, 200, "ok", "", nil)
 	return mvc.Response{Object: iris.Map{
 		"server": iris.Map{
 			"name":    "rustdesk-api-server-pro",
@@ -117,15 +124,17 @@ func (c *CompatPublicController) HandleClientConfig() mvc.Result {
 		},
 		"compat_target": c.compatService().Target(),
 		"features": iris.Map{
-			"address_book": true,
-			"audit":        true,
-			"record":       true,
+			"address_book":     true,
+			"audit":            true,
+			"record":           true,
+			"compat_api_audit": true,
 		},
 		"login_options": c.compatService().LoginOptions().Options,
 	}}
 }
 
 func (c *CompatPublicController) HandleSysinfoVer() mvc.Result {
+	c.recordCompatAPIAudit(false, 200, "ok", "", nil)
 	return mvc.Response{
 		Text: service.CompatSysinfoVersion,
 	}
@@ -133,6 +142,12 @@ func (c *CompatPublicController) HandleSysinfoVer() mvc.Result {
 
 func (c *CompatPublicController) HandleOidcAuth() mvc.Result {
 	result := c.compatService().OidcAuth()
+	isStub := !result.Enabled
+	auditResult := result.Error
+	if auditResult == "" {
+		auditResult = "ok"
+	}
+	c.recordCompatAPIAudit(isStub, 200, auditResult, "", nil)
 	return mvc.Response{
 		Object: iris.Map{
 			"error":   result.Error,
@@ -144,6 +159,12 @@ func (c *CompatPublicController) HandleOidcAuth() mvc.Result {
 
 func (c *CompatPublicController) HandleOidcAuthQuery() mvc.Result {
 	result := c.compatService().OidcAuthQuery()
+	isStub := result.Error != ""
+	auditResult := result.Error
+	if auditResult == "" {
+		auditResult = "ok"
+	}
+	c.recordCompatAPIAudit(isStub, 200, auditResult, "", nil)
 	return mvc.Response{
 		Object: iris.Map{
 			"error":   result.Error,
@@ -157,6 +178,7 @@ func (c *CompatPublicController) HandleRecord() mvc.Result {
 	offset, _ := strconv.ParseInt(c.Ctx.URLParamDefault("offset", "0"), 10, 64)
 	body, err := c.readBodyBytes()
 	if err != nil {
+		c.recordCompatAPIAudit(true, 400, "error", err.Error(), nil)
 		return c.fail(err)
 	}
 	err = c.compatService().HandleRecord(core.CompatRecordCommand{
@@ -166,13 +188,16 @@ func (c *CompatPublicController) HandleRecord() mvc.Result {
 		Body:     body,
 	})
 	if err != nil {
+		c.recordCompatAPIAudit(true, 400, "error", err.Error(), body)
 		return c.fail(err)
 	}
+	c.recordCompatAPIAudit(false, 200, "ok", "", body)
 	return c.ok()
 }
 
 func (c *CompatPublicController) HandleDevicesDeploy() mvc.Result {
 	if c.Ctx.Method() == iris.MethodGet {
+		c.recordCompatAPIAudit(true, 200, "NOT_ENABLED", "", nil)
 		return mvc.Response{Object: iris.Map{"result": "NOT_ENABLED"}}
 	}
 
@@ -182,6 +207,11 @@ func (c *CompatPublicController) HandleDevicesDeploy() mvc.Result {
 		UUID:      gjson.GetBytes(body, "uuid").String(),
 		PublicKey: gjson.GetBytes(body, "pk").String(),
 	})
+	statusCode := 200
+	if result.Result == "INVALID_INPUT" {
+		statusCode = 400
+	}
+	c.recordCompatAPIAudit(true, statusCode, result.Result, "", body)
 	return mvc.Response{
 		Object: iris.Map{
 			"result": result.Result,

--- a/backend/app/controller/api/login.go
+++ b/backend/app/controller/api/login.go
@@ -3,7 +3,9 @@ package api
 import (
 	apiform "rustdesk-api-server-pro/app/form/api"
 	"rustdesk-api-server-pro/config"
+	"rustdesk-api-server-pro/internal/core"
 
+	"github.com/kataras/iris/v12"
 	"github.com/kataras/iris/v12/mvc"
 )
 
@@ -20,16 +22,55 @@ func (c *LoginController) BeforeActivation(b mvc.BeforeActivation) {
 func (c *LoginController) PostLogin() mvc.Result {
 	var loginForm apiform.LoginForm
 	if err := c.readJSONBody(&loginForm); err != nil {
+		c.recordClientLoginAudit("", false, "decode_error: "+err.Error())
 		return c.fail(err)
 	}
 
 	result := c.loginService().HandleLogin(loginForm)
+	success, reason := clientLoginAuditResult(result)
+	c.recordClientLoginAudit(loginForm.Username, success, reason)
 	return mvc.Response{Object: result}
 }
 
 func (c *LoginController) HandleLoginOptions() mvc.Result {
 	result := c.compatService().LoginOptions()
+	c.recordCompatAPIAudit(false, 200, "ok", "", nil)
 	return mvc.Response{
 		Object: result.Options,
 	}
+}
+
+func (c *LoginController) recordClientLoginAudit(username string, success bool, reason string) {
+	if reason == "" {
+		if success {
+			reason = "access_token"
+		} else {
+			reason = "unknown"
+		}
+	}
+	_ = c.auditService().CreateSecurityAudit(core.SecurityAuditCreateCommand{
+		Username:  username,
+		Event:     "api_login",
+		IP:        c.Ctx.RemoteAddr(),
+		UserAgent: c.Ctx.GetHeader("User-Agent"),
+		Success:   success,
+		Reason:    reason,
+	})
+}
+
+func clientLoginAuditResult(result any) (bool, string) {
+	m, ok := result.(iris.Map)
+	if !ok {
+		return false, "unexpected_response"
+	}
+	if errValue, exists := m["error"]; exists {
+		return false, stringFromAny(errValue)
+	}
+	if _, exists := m["access_token"]; exists {
+		return true, "access_token"
+	}
+	if t, exists := m["type"]; exists {
+		return false, "pending_" + stringFromAny(t)
+	}
+	return false, "pending_or_unknown"
 }

--- a/backend/app/controller/api/user.go
+++ b/backend/app/controller/api/user.go
@@ -58,6 +58,7 @@ func (c *UserController) GetUsers() mvc.Result {
 }
 
 func (c *UserController) HandleLogout() mvc.Result {
+	user := c.GetUser()
 	rustdeskID := c.Ctx.URLParamDefault("id", "")
 	if rustdeskID == "" {
 		rustdeskID = c.Ctx.URLParamDefault("rustdesk_id", "")
@@ -70,8 +71,11 @@ func (c *UserController) HandleLogout() mvc.Result {
 		}
 	}
 
+	logoutMode := "token"
 	if rustdeskID != "" {
+		logoutMode = "rustdesk_id"
 		if err := c.userService().LogoutByRustdeskID(rustdeskID); err != nil {
+			c.recordUserSecurityAudit(user, "api_logout", false, "logout_by_rustdesk_id: "+err.Error())
 			return c.fail(err)
 		}
 	} else {
@@ -82,10 +86,27 @@ func (c *UserController) HandleLogout() mvc.Result {
 				Status:  0,
 			})
 			if err != nil {
+				c.recordUserSecurityAudit(user, "api_logout", false, "logout_by_token: "+err.Error())
 				return c.fail(err)
 			}
 		}
 	}
 
+	c.recordUserSecurityAudit(user, "api_logout", true, logoutMode)
 	return c.okText("ok")
+}
+
+func (c *UserController) recordUserSecurityAudit(user *model.User, event string, success bool, reason string) {
+	cmd := core.SecurityAuditCreateCommand{
+		Event:     event,
+		IP:        c.Ctx.RemoteAddr(),
+		UserAgent: c.Ctx.GetHeader("User-Agent"),
+		Success:   success,
+		Reason:    reason,
+	}
+	if user != nil {
+		cmd.UserID = user.Id
+		cmd.Username = user.Username
+	}
+	_ = c.auditService().CreateSecurityAudit(cmd)
 }

--- a/backend/app/middleware/auth.go
+++ b/backend/app/middleware/auth.go
@@ -20,6 +20,7 @@ func ApiAuth(app *iris.Application) iris.Handler {
 		var authToken model.AuthToken
 		get, err := db.Where("token = ? and expired > ? and status = 1 and is_admin = 0", token, time.Now().Format(config.TimeFormat)).Get(&authToken)
 		if !get || err != nil {
+			recordAuthSecurityAudit(db, context, "api_token_invalid", 0, "", false, authFailureReason(err, "Unauthorized"))
 			context.StopWithText(iris.StatusUnauthorized, "Unauthorized")
 			return
 		}
@@ -27,6 +28,7 @@ func ApiAuth(app *iris.Application) iris.Handler {
 		var user model.User
 		get, err = db.Where("id = ? and status > 0", authToken.UserId).Get(&user)
 		if !get || err != nil {
+			recordAuthSecurityAudit(db, context, "api_token_user_invalid", authToken.UserId, "", false, authFailureReason(err, "NotAcceptable"))
 			context.StopWithText(iris.StatusNotAcceptable, "NotAcceptable")
 			return
 		}
@@ -46,6 +48,7 @@ func AdminAuth(app *iris.Application) iris.Handler {
 		var authToken model.AuthToken
 		get, err := db.Where("token = ? and expired > ? and status = 1 and is_admin = 1", token, time.Now().Format(config.TimeFormat)).Get(&authToken)
 		if !get || err != nil {
+			recordAuthSecurityAudit(db, context, "admin_token_invalid", 0, "", false, authFailureReason(err, "Unauthorized"))
 			context.StopWithText(iris.StatusUnauthorized, "Unauthorized")
 			return
 		}
@@ -53,6 +56,7 @@ func AdminAuth(app *iris.Application) iris.Handler {
 		var user model.User
 		get, err = db.Where("id = ? and status > 0 and is_admin = 1", authToken.UserId).Get(&user)
 		if !get || err != nil {
+			recordAuthSecurityAudit(db, context, "admin_token_user_invalid", authToken.UserId, "", false, authFailureReason(err, "NotAcceptable"))
 			context.StopWithText(iris.StatusNotAcceptable, "NotAcceptable")
 			return
 		}
@@ -68,4 +72,26 @@ func AdminAuth(app *iris.Application) iris.Handler {
 		context.Values().Set(config.AdminAuthToken, &authToken)
 		context.Next()
 	}
+}
+
+func recordAuthSecurityAudit(db *xorm.Engine, context iris.Context, event string, userID int, username string, success bool, reason string) {
+	if db == nil || context == nil {
+		return
+	}
+	_, _ = db.Insert(&model.SecurityAudit{
+		UserId:    userID,
+		Username:  username,
+		Event:     event,
+		IP:        context.RemoteAddr(),
+		UserAgent: context.GetHeader("User-Agent"),
+		Success:   success,
+		Reason:    reason,
+	})
+}
+
+func authFailureReason(err error, fallback string) string {
+	if err != nil {
+		return err.Error()
+	}
+	return fallback
 }

--- a/backend/app/model/audit.go
+++ b/backend/app/model/audit.go
@@ -93,6 +93,9 @@ type CompatAPIAudit struct {
 	StatusCode    int       `xorm:"'status_code' int"`
 	IP            string    `xorm:"'ip' varchar(64)"`
 	UserAgent     string    `xorm:"'user_agent' varchar(512)"`
+	Result        string    `xorm:"'result' varchar(32) index"`
+	ErrorMessage  string    `xorm:"'error_message' varchar(1024)"`
+	BodyDigest    string    `xorm:"'body_digest' varchar(128)"`
 	CreatedAt     time.Time `xorm:"'created_at' datetime created index"`
 }
 

--- a/backend/internal/core/audit.go
+++ b/backend/internal/core/audit.go
@@ -98,4 +98,7 @@ type CompatAPIAuditCreateCommand struct {
 	StatusCode    int
 	IP            string
 	UserAgent     string
+	Result        string
+	ErrorMessage  string
+	BodyDigest    string
 }

--- a/backend/internal/repository/xorm_audit_repository.go
+++ b/backend/internal/repository/xorm_audit_repository.go
@@ -161,6 +161,10 @@ func (r *XormAuditRepository) InsertOperationAudit(cmd core.OperationAuditCreate
 }
 
 func (r *XormAuditRepository) InsertCompatAPIAudit(cmd core.CompatAPIAuditCreateCommand) error {
+	result := cmd.Result
+	if result == "" {
+		result = "ok"
+	}
 	_, err := r.DB.Insert(&model.CompatAPIAudit{
 		Method:        cmd.Method,
 		Path:          cmd.Path,
@@ -170,6 +174,9 @@ func (r *XormAuditRepository) InsertCompatAPIAudit(cmd core.CompatAPIAuditCreate
 		StatusCode:    cmd.StatusCode,
 		IP:            cmd.IP,
 		UserAgent:     cmd.UserAgent,
+		Result:        result,
+		ErrorMessage:  cmd.ErrorMessage,
+		BodyDigest:    cmd.BodyDigest,
 	})
 	return err
 }

--- a/backend/internal/service/compat_service.go
+++ b/backend/internal/service/compat_service.go
@@ -54,6 +54,7 @@ func (s *CompatService) Target() map[string]any {
 			"audit":                   true,
 			"file_transfer_audit":     true,
 			"alarm_audit":             true,
+			"compat_api_audit":        true,
 			"device_group":            true,
 			"user_group":              true,
 			"strategy":                true,

--- a/backend/internal/service/compat_service.go
+++ b/backend/internal/service/compat_service.go
@@ -88,6 +88,7 @@ func (s *CompatService) Target() map[string]any {
 			"/api/compat/version",
 			"/api/sysinfo_ver",
 			"/api/devices/deploy",
+			"/lic/web/api/plugin-sign",
 		},
 	}
 }

--- a/backend/internal/service/compat_service.go
+++ b/backend/internal/service/compat_service.go
@@ -87,6 +87,7 @@ func (s *CompatService) Target() map[string]any {
 			"/api/compat/target",
 			"/api/compat/version",
 			"/api/sysinfo_ver",
+			"/api/login-options",
 			"/api/devices/deploy",
 			"/lic/web/api/plugin-sign",
 		},

--- a/backend/internal/service/compat_service_test.go
+++ b/backend/internal/service/compat_service_test.go
@@ -152,6 +152,7 @@ func TestCompatServiceTargetContract(t *testing.T) {
 		"audit",
 		"file_transfer_audit",
 		"alarm_audit",
+		"compat_api_audit",
 		"device_group",
 		"user_group",
 		"strategy",

--- a/backend/internal/service/compat_service_test.go
+++ b/backend/internal/service/compat_service_test.go
@@ -178,7 +178,7 @@ func TestCompatServiceTargetContract(t *testing.T) {
 	if !ok {
 		t.Fatalf("probe_endpoints should be []string")
 	}
-	for _, path := range []string{"/api/health", "/api/compat-target", "/api/server/info", "/api/devices/deploy"} {
+	for _, path := range []string{"/api/health", "/api/compat-target", "/api/server/info", "/api/login-options", "/api/devices/deploy", "/lic/web/api/plugin-sign"} {
 		if !containsString(endpoints, path) {
 			t.Fatalf("expected probe_endpoints to contain %s", path)
 		}

--- a/docs/API_MATRIX.md
+++ b/docs/API_MATRIX.md
@@ -33,6 +33,7 @@
 | --- | --- | --- | --- | --- | --- |
 | 用户 | GET/POST | `/api/user/*` | 是 | 待核验 | 用户信息、当前账号 |
 | 退出登录 | GET/POST/DELETE | `/api/logout` | 是 | 基础 | 退出登录成功/失败已写 `security_audit` |
+| token 鉴权 | * | `/api/*` 鉴权接口 | 是 | 基础 | 客户端 token 无效、token 对应用户无效已写 `security_audit` |
 | 地址簿 | GET/POST | `/api/peers/*` | 是 | 基础 | 老接口地址簿兼容 |
 | 地址簿 | GET/POST | `/api/ab/*` | 是 | 基础 | 新地址簿主体 |
 | 地址簿标签 | GET/POST | `/api/ab/tags/*` | 是 | 基础 | 标签、颜色、备注兼容 |
@@ -45,7 +46,7 @@
 
 | 模块 | 路径 | 状态 | 建议 |
 | --- | --- | --- | --- |
-| 后台登录 | `/admin/auth/*` | 基础 | 管理员账号登录成功/失败已写 `security_audit`；OIDC/OAuth 回调审计待补 |
+| 后台登录 | `/admin/auth/*` | 基础 | 管理员账号登录成功/失败、OIDC/OAuth 回调与 ticket 换 token、后台 token 无效已写 `security_audit` |
 | 仪表盘 | `/admin/dashboard/*` | 已有 | 增加审计概览 |
 | 用户管理 | `/admin/users/*` | 已有 | 增加操作审计 |
 | 会话管理 | `/admin/sessions/*` | 已有 | 增加 token 安全事件 |
@@ -74,10 +75,15 @@
 | 客户端登录失败 | 是 | `security_audit` | P0 |
 | 客户端验证码/2FA 中间态 | 是 | `security_audit` | P1 |
 | 客户端退出登录 | 是 | `security_audit` | P1 |
+| 客户端 token 无效 | 是 | `security_audit` | P1 |
+| 客户端 token 对应用户无效 | 是 | `security_audit` | P1 |
 | 后台登录成功 | 是 | `security_audit` | P0 |
 | 后台登录失败 | 是 | `security_audit` | P0 |
-| OIDC/OAuth 回调失败 | 待补 | `security_audit` | P1 |
-| token 无效 | 待补 | `security_audit` | P1 |
+| 后台 token 无效 | 是 | `security_audit` | P1 |
+| 后台 token 对应管理员无效 | 是 | `security_audit` | P1 |
+| OIDC/OAuth 回调成功 | 是 | `security_audit` | P1 |
+| OIDC/OAuth 回调失败 | 是 | `security_audit` | P1 |
+| OIDC/OAuth ticket 换 token | 是 | `security_audit` | P1 |
 | 后台新增用户 | 待补 | `operation_audit` | P0 |
 | 后台修改用户 | 待补 | `operation_audit` | P0 |
 | 后台删除用户 | 待补 | `operation_audit` | P0 |
@@ -108,7 +114,7 @@ MySQL 验证：通过/失败
 ## 7. 下一批建议开发任务
 
 1. 后台审计页面增加 `security_audit` / `compat_api_audit` 视图，按事件、path、method、is_stub、result、client_version 聚合。
-2. 新增 OIDC/OAuth 回调成功/失败审计。
-3. 新增 `operation_audit` 接入用户管理增删改。
-4. 建立真实 RustDesk 客户端抓包样例目录，补齐官方接口字段差异。
-5. 对 `/lic/web/api/*` 继续做真实客户端验证，避免误以为 plugin-sign 透传等价于官方签名服务。
+2. 新增 `operation_audit` 接入用户管理增删改。
+3. 建立真实 RustDesk 客户端抓包样例目录，补齐官方接口字段差异。
+4. 对 `/lic/web/api/*` 继续做真实客户端验证，避免误以为 plugin-sign 透传等价于官方签名服务。
+5. 增强 authenticated smoke：用测试用户登录后验证 `/api/currentUser`、`/api/logout` 和安全审计落库。

--- a/docs/API_MATRIX.md
+++ b/docs/API_MATRIX.md
@@ -48,7 +48,7 @@
 | --- | --- | --- | --- |
 | 后台登录 | `/admin/auth/*` | 基础 | 管理员账号登录成功/失败、OIDC/OAuth 回调与 ticket 换 token、后台 token 无效已写 `security_audit` |
 | 仪表盘 | `/admin/dashboard/*` | 已有 | 增加审计概览 |
-| 用户管理 | `/admin/users/*` | 已有 | 增加操作审计 |
+| 用户管理 | `/admin/users/*` | 基础 | 新增、修改、删除用户已写 `operation_audit`；不记录密码和 2FA 密钥明文 |
 | 会话管理 | `/admin/sessions/*` | 已有 | 增加 token 安全事件 |
 | 设备管理 | `/admin/devices/*` | 已有 | 增加设备变更审计 |
 | 审计日志 | `/admin/audit/*` | 已有 | 增加高级筛选、导出、报警审计、兼容探测审计视图 |
@@ -84,9 +84,9 @@
 | OIDC/OAuth 回调成功 | 是 | `security_audit` | P1 |
 | OIDC/OAuth 回调失败 | 是 | `security_audit` | P1 |
 | OIDC/OAuth ticket 换 token | 是 | `security_audit` | P1 |
-| 后台新增用户 | 待补 | `operation_audit` | P0 |
-| 后台修改用户 | 待补 | `operation_audit` | P0 |
-| 后台删除用户 | 待补 | `operation_audit` | P0 |
+| 后台新增用户 | 是 | `operation_audit` | P0 |
+| 后台修改用户 | 是 | `operation_audit` | P0 |
+| 后台删除用户 | 是 | `operation_audit` | P0 |
 | 修改设备 | 待补 | `operation_audit` | P1 |
 | 修改地址簿 | 待补 | `operation_audit` | P1 |
 | 修改策略 | 待补 | `operation_audit` | P2 |
@@ -113,8 +113,9 @@ MySQL 验证：通过/失败
 
 ## 7. 下一批建议开发任务
 
-1. 后台审计页面增加 `security_audit` / `compat_api_audit` 视图，按事件、path、method、is_stub、result、client_version 聚合。
-2. 新增 `operation_audit` 接入用户管理增删改。
-3. 建立真实 RustDesk 客户端抓包样例目录，补齐官方接口字段差异。
-4. 对 `/lic/web/api/*` 继续做真实客户端验证，避免误以为 plugin-sign 透传等价于官方签名服务。
-5. 增强 authenticated smoke：用测试用户登录后验证 `/api/currentUser`、`/api/logout` 和安全审计落库。
+1. 后台审计页面增加 `security_audit` / `compat_api_audit` / `operation_audit` 视图，按事件、path、method、is_stub、result、client_version、resource_type 聚合。
+2. 新增 `operation_audit` 接入设备管理修改。
+3. 新增 `operation_audit` 接入地址簿和策略修改。
+4. 建立真实 RustDesk 客户端抓包样例目录，补齐官方接口字段差异。
+5. 对 `/lic/web/api/*` 继续做真实客户端验证，避免误以为 plugin-sign 透传等价于官方签名服务。
+6. 增强 authenticated smoke：用测试用户登录后验证 `/api/currentUser`、`/api/logout` 和安全审计落库。

--- a/docs/API_MATRIX.md
+++ b/docs/API_MATRIX.md
@@ -32,6 +32,7 @@
 | 模块 | 方法 | 路径 | 鉴权 | 状态 | 说明 |
 | --- | --- | --- | --- | --- | --- |
 | 用户 | GET/POST | `/api/user/*` | 是 | 待核验 | 用户信息、当前账号 |
+| 退出登录 | GET/POST/DELETE | `/api/logout` | 是 | 基础 | 退出登录成功/失败已写 `security_audit` |
 | 地址簿 | GET/POST | `/api/peers/*` | 是 | 基础 | 老接口地址簿兼容 |
 | 地址簿 | GET/POST | `/api/ab/*` | 是 | 基础 | 新地址簿主体 |
 | 地址簿标签 | GET/POST | `/api/ab/tags/*` | 是 | 基础 | 标签、颜色、备注兼容 |
@@ -72,10 +73,10 @@
 | 客户端登录成功 | 是 | `security_audit` | P0 |
 | 客户端登录失败 | 是 | `security_audit` | P0 |
 | 客户端验证码/2FA 中间态 | 是 | `security_audit` | P1 |
+| 客户端退出登录 | 是 | `security_audit` | P1 |
 | 后台登录成功 | 是 | `security_audit` | P0 |
 | 后台登录失败 | 是 | `security_audit` | P0 |
 | OIDC/OAuth 回调失败 | 待补 | `security_audit` | P1 |
-| 退出登录 | 待补 | `security_audit` | P1 |
 | token 无效 | 待补 | `security_audit` | P1 |
 | 后台新增用户 | 待补 | `operation_audit` | P0 |
 | 后台修改用户 | 待补 | `operation_audit` | P0 |

--- a/docs/API_MATRIX.md
+++ b/docs/API_MATRIX.md
@@ -20,7 +20,8 @@
 | 系统 | GET/POST | `/api/config`、`/api/client-config`、`/api/server-config` | 否 | 基础 | 返回客户端配置形状，已纳入 smoke 与兼容命中审计 |
 | 系统 | GET/POST | `/api/compat-target`、`/api/compat/target`、`/api/compat/version` | 否 | 基础 | 返回当前匹配对象，目标 RustDesk 1.4.8 |
 | 系统 | GET/POST | `/api/sysinfo_ver` | 否 | 基础 | 返回兼容 sysinfo 版本字符串 |
-| 登录 | POST | `/api/login` | 否 | 待核验 | 账号登录、token 返回，需要真实客户端继续验证字段兼容 |
+| 登录 | GET/POST | `/api/login-options` | 否 | 基础 | 返回可用登录方式，已纳入公开 smoke 与兼容命中审计 |
+| 登录 | POST | `/api/login` | 否 | 基础/待核验 | 账号登录、token 返回；成功/失败/验证码或 2FA 中间态已写 `security_audit` |
 | 审计 | POST | `/api/audit/conn` | 否/待核验 | 基础 | 连接开始、关闭、备注更新 |
 | 审计 | POST | `/api/audit/file` | 否/待核验 | 基础 | 文件传输日志 |
 | 审计 | POST | `/api/audit/alarm` | 否/待核验 | 基础 | 已落库到 `alarm_audit` |
@@ -43,7 +44,7 @@
 
 | 模块 | 路径 | 状态 | 建议 |
 | --- | --- | --- | --- |
-| 后台登录 | `/admin/auth/*` | 已有 | 增加登录安全审计 |
+| 后台登录 | `/admin/auth/*` | 基础 | 管理员账号登录成功/失败已写 `security_audit`；OIDC/OAuth 回调审计待补 |
 | 仪表盘 | `/admin/dashboard/*` | 已有 | 增加审计概览 |
 | 用户管理 | `/admin/users/*` | 已有 | 增加操作审计 |
 | 会话管理 | `/admin/sessions/*` | 已有 | 增加 token 安全事件 |
@@ -68,8 +69,12 @@
 | 连接备注修改 | 是 | `audit` | P0 |
 | 文件传输 | 是 | `file_transfer` | P0 |
 | 客户端报警 | 是 | `alarm_audit` | P1 |
-| 登录成功 | 待补 | `security_audit` | P0 |
-| 登录失败 | 待补 | `security_audit` | P0 |
+| 客户端登录成功 | 是 | `security_audit` | P0 |
+| 客户端登录失败 | 是 | `security_audit` | P0 |
+| 客户端验证码/2FA 中间态 | 是 | `security_audit` | P1 |
+| 后台登录成功 | 是 | `security_audit` | P0 |
+| 后台登录失败 | 是 | `security_audit` | P0 |
+| OIDC/OAuth 回调失败 | 待补 | `security_audit` | P1 |
 | 退出登录 | 待补 | `security_audit` | P1 |
 | token 无效 | 待补 | `security_audit` | P1 |
 | 后台新增用户 | 待补 | `operation_audit` | P0 |
@@ -101,8 +106,8 @@ MySQL 验证：通过/失败
 
 ## 7. 下一批建议开发任务
 
-1. 后台审计页面增加 `compat_api_audit` 视图，按 path/method/is_stub/result/client_version 聚合。
-2. 新增 `security_audit` 接入后台登录成功/失败。
+1. 后台审计页面增加 `security_audit` / `compat_api_audit` 视图，按事件、path、method、is_stub、result、client_version 聚合。
+2. 新增 OIDC/OAuth 回调成功/失败审计。
 3. 新增 `operation_audit` 接入用户管理增删改。
 4. 建立真实 RustDesk 客户端抓包样例目录，补齐官方接口字段差异。
 5. 对 `/lic/web/api/*` 继续做真实客户端验证，避免误以为 plugin-sign 透传等价于官方签名服务。

--- a/docs/API_MATRIX.md
+++ b/docs/API_MATRIX.md
@@ -14,12 +14,17 @@
 
 | 模块 | 方法 | 路径 | 鉴权 | 状态 | 说明 |
 | --- | --- | --- | --- | --- | --- |
-| 系统 | GET | `/api/` | 否 | 待核验 | 健康检查或基础信息 |
-| 登录 | POST | `/api/login` | 否 | 待核验 | 账号登录、token 返回 |
+| 系统 | GET/POST | `/api/health`、`/api/ping` | 否 | 基础 | 健康检查，已纳入 smoke 与兼容命中审计 |
+| 系统 | GET/POST | `/api/status`、`/api/version`、`/api/info` | 否 | 基础 | 返回版本与 `compat_target`，已纳入 smoke 与兼容命中审计 |
+| 系统 | GET/POST | `/api/features`、`/api/capabilities`、`/api/compat/features` | 否 | 基础 | 返回能力开关，包含 `compat_api_audit` |
+| 系统 | GET/POST | `/api/config`、`/api/client-config`、`/api/server-config` | 否 | 基础 | 返回客户端配置形状，已纳入 smoke 与兼容命中审计 |
+| 系统 | GET/POST | `/api/compat-target`、`/api/compat/target`、`/api/compat/version` | 否 | 基础 | 返回当前匹配对象，目标 RustDesk 1.4.8 |
+| 系统 | GET/POST | `/api/sysinfo_ver` | 否 | 基础 | 返回兼容 sysinfo 版本字符串 |
+| 登录 | POST | `/api/login` | 否 | 待核验 | 账号登录、token 返回，需要真实客户端继续验证字段兼容 |
 | 审计 | POST | `/api/audit/conn` | 否/待核验 | 基础 | 连接开始、关闭、备注更新 |
 | 审计 | POST | `/api/audit/file` | 否/待核验 | 基础 | 文件传输日志 |
-| 审计 | POST | `/api/audit/alarm` | 否/待核验 | 占位 | 当前建议改为落库 |
-| 兼容 | * | `/api/*` | 否 | 待核验 | 公开兼容控制器 |
+| 审计 | POST | `/api/audit/alarm` | 否/待核验 | 基础 | 已落库到 `alarm_audit` |
+| 兼容 | * | `/api/*` 公开探测别名 | 否 | 基础 | 公开兼容控制器已写入 `compat_api_audit`，用于发现新版客户端真实探测 |
 
 ## 2. 客户端鉴权接口
 
@@ -43,7 +48,7 @@
 | 用户管理 | `/admin/users/*` | 已有 | 增加操作审计 |
 | 会话管理 | `/admin/sessions/*` | 已有 | 增加 token 安全事件 |
 | 设备管理 | `/admin/devices/*` | 已有 | 增加设备变更审计 |
-| 审计日志 | `/admin/audit/*` | 已有 | 增加高级筛选、导出、报警审计 |
+| 审计日志 | `/admin/audit/*` | 已有 | 增加高级筛选、导出、报警审计、兼容探测审计视图 |
 | 邮件模板 | `/admin/mail-template/*` | 已有 | 增加修改审计 |
 | 邮件日志 | `/admin/mail-logs/*` | 已有 | 增加发送失败分析 |
 
@@ -51,7 +56,7 @@
 
 | 方法 | 路径 | 状态 | 建议 |
 | --- | --- | --- | --- |
-| * | `/lic/web/api/plugin-sign` | 基础/占位 | 增加配置化返回、调用审计 |
+| POST | `/lic/web/api/plugin-sign` | 基础/占位 | 已纳入 smoke 与 `compat_api_audit`；当前为稳定 JSON 形状 + 消息透传，不声明官方签名等价 |
 | * | `/lic/web/api/*` | 待核验 | 建立真实客户端抓包验证样例 |
 
 ## 5. 审计覆盖矩阵
@@ -62,7 +67,7 @@
 | 远程连接关闭 | 是 | `audit` / `connection_audit` | P0 |
 | 连接备注修改 | 是 | `audit` | P0 |
 | 文件传输 | 是 | `file_transfer` | P0 |
-| 客户端报警 | 否，占位 | `alarm_audit` | P1 |
+| 客户端报警 | 是 | `alarm_audit` | P1 |
 | 登录成功 | 待补 | `security_audit` | P0 |
 | 登录失败 | 待补 | `security_audit` | P0 |
 | 退出登录 | 待补 | `security_audit` | P1 |
@@ -73,7 +78,7 @@
 | 修改设备 | 待补 | `operation_audit` | P1 |
 | 修改地址簿 | 待补 | `operation_audit` | P1 |
 | 修改策略 | 待补 | `operation_audit` | P2 |
-| 占位接口命中 | 待补 | `compat_api_audit` | P1 |
+| 兼容/占位接口命中 | 是 | `compat_api_audit` | P1 |
 
 ## 6. 每个接口的记录模板
 
@@ -94,12 +99,10 @@ MySQL 验证：通过/失败
 备注：
 ```
 
-## 7. 第一批建议开发任务
+## 7. 下一批建议开发任务
 
-1. `/api/audit/alarm` 落库。
-2. 扩展 `audit` 字段：`peer_id`、`direction`、`status`、`client_version`、`raw`、`duration_seconds`。
-3. 扩展 `file_transfer` 字段：`session_id`、`direction`、`size_bytes`、`result`、`error_message`、`raw`。
-4. 新增 `security_audit`，接入后台登录成功/失败。
-5. 新增 `operation_audit`，接入用户管理增删改。
-6. 新增 `compat_api_audit`，记录占位接口命中。
-7. 后台审计页面增加类型切换与高级筛选。
+1. 后台审计页面增加 `compat_api_audit` 视图，按 path/method/is_stub/result/client_version 聚合。
+2. 新增 `security_audit` 接入后台登录成功/失败。
+3. 新增 `operation_audit` 接入用户管理增删改。
+4. 建立真实 RustDesk 客户端抓包样例目录，补齐官方接口字段差异。
+5. 对 `/lic/web/api/*` 继续做真实客户端验证，避免误以为 plugin-sign 透传等价于官方签名服务。

--- a/docs/API_MATRIX.md
+++ b/docs/API_MATRIX.md
@@ -48,7 +48,7 @@
 | --- | --- | --- | --- |
 | 后台登录 | `/admin/auth/*` | 基础 | 管理员账号登录成功/失败、OIDC/OAuth 回调与 ticket 换 token、后台 token 无效已写 `security_audit` |
 | 仪表盘 | `/admin/dashboard/*` | 已有 | 增加审计概览 |
-| 用户管理 | `/admin/users/*` | 基础 | 新增、修改、删除用户已写 `operation_audit`；不记录密码和 2FA 密钥明文 |
+| 用户管理 | `/admin/users/*` | 基础 | 新增、修改、删除用户已写 `operation_audit`；不记录密码和 2FA 密钥明文；空删除列表会返回 `NoUserIds` 并记录失败审计 |
 | 会话管理 | `/admin/sessions/*` | 已有 | 增加 token 安全事件 |
 | 设备管理 | `/admin/devices/*` | 已有 | 增加设备变更审计 |
 | 审计日志 | `/admin/audit/*` | 已有 | 增加高级筛选、导出、报警审计、兼容探测审计视图 |

--- a/docs/compat/rustdesk-current.json
+++ b/docs/compat/rustdesk-current.json
@@ -42,11 +42,11 @@
     "/api/compat/target",
     "/api/compat/version",
     "/api/sysinfo_ver",
+    "/api/login-options",
     "/api/devices/deploy",
     "/lic/web/api/plugin-sign"
   ],
   "authenticated_endpoints": [
-    "/api/login-options",
     "/api/currentUser",
     "/api/logout",
     "/api/ab/personal",
@@ -76,9 +76,9 @@
     "/api/compat/target",
     "/api/compat/version",
     "/api/sysinfo_ver",
+    "/api/login-options",
     "/api/devices/deploy",
     "/lic/web/api/plugin-sign",
-    "/api/login-options",
     "/api/currentUser",
     "/api/logout",
     "/api/ab/personal",

--- a/docs/compat/rustdesk-current.json
+++ b/docs/compat/rustdesk-current.json
@@ -42,7 +42,8 @@
     "/api/compat/target",
     "/api/compat/version",
     "/api/sysinfo_ver",
-    "/api/devices/deploy"
+    "/api/devices/deploy",
+    "/lic/web/api/plugin-sign"
   ],
   "authenticated_endpoints": [
     "/api/login-options",
@@ -76,6 +77,7 @@
     "/api/compat/version",
     "/api/sysinfo_ver",
     "/api/devices/deploy",
+    "/lic/web/api/plugin-sign",
     "/api/login-options",
     "/api/currentUser",
     "/api/logout",

--- a/scripts/compat/smoke-api.sh
+++ b/scripts/compat/smoke-api.sh
@@ -30,6 +30,31 @@ request() {
   fi
 }
 
+request_json() {
+  local method="$1"
+  local path="$2"
+  local payload="$3"
+  local expect="$4"
+  local url="${BASE_URL%/}${path}"
+  local args=(-fsS -X "$method" "$url" -H "Content-Type: application/json" --data "$payload")
+  if [ -n "$TOKEN" ]; then
+    args+=(-H "Authorization: Bearer $TOKEN")
+  fi
+
+  echo "==> $method $path"
+  if out="$(curl "${args[@]}" 2>&1)"; then
+    if [ -n "$expect" ] && ! grep -q "$expect" <<<"$out"; then
+      echo "Expected to find '$expect' but got: $out" >&2
+      failures=$((failures + 1))
+    else
+      echo "OK"
+    fi
+  else
+    echo "FAILED: $out" >&2
+    failures=$((failures + 1))
+  fi
+}
+
 # Public compatibility probes. These should not require login.
 request GET  /api/health "ok"
 request GET  /api/ping "ok"
@@ -51,6 +76,9 @@ request GET  /api/compat/target "1.4.8"
 request GET  /api/compat/version "1.4.8"
 request GET  /api/sysinfo_ver "1.4.8"
 request GET  /api/devices/deploy "NOT_ENABLED"
+
+# License/plugin compatibility endpoint. It is a passthrough placeholder but should keep a stable JSON shape.
+request_json POST /lic/web/api/plugin-sign '{"plugin_id":"compat-smoke","version":"1.4.8","msg":"c21va2U="}' "signed_msg"
 
 if [ -n "$TOKEN" ]; then
   request GET  /api/currentUser "data"

--- a/scripts/compat/smoke-api.sh
+++ b/scripts/compat/smoke-api.sh
@@ -18,7 +18,7 @@ request() {
 
   echo "==> $method $path"
   if out="$(curl "${args[@]}" 2>&1)"; then
-    if [ -n "$expect" ] && ! grep -q "$expect" <<<"$out"; then
+    if [ -n "$expect" ] && ! grep -Fq "$expect" <<<"$out"; then
       echo "Expected to find '$expect' but got: $out" >&2
       failures=$((failures + 1))
     else
@@ -43,7 +43,7 @@ request_json() {
 
   echo "==> $method $path"
   if out="$(curl "${args[@]}" 2>&1)"; then
-    if [ -n "$expect" ] && ! grep -q "$expect" <<<"$out"; then
+    if [ -n "$expect" ] && ! grep -Fq "$expect" <<<"$out"; then
       echo "Expected to find '$expect' but got: $out" >&2
       failures=$((failures + 1))
     else

--- a/scripts/compat/smoke-api.sh
+++ b/scripts/compat/smoke-api.sh
@@ -75,6 +75,7 @@ request GET  /api/compat-target "1.4.8"
 request GET  /api/compat/target "1.4.8"
 request GET  /api/compat/version "1.4.8"
 request GET  /api/sysinfo_ver "1.4.8"
+request GET  /api/login-options "["
 request GET  /api/devices/deploy "NOT_ENABLED"
 
 # License/plugin compatibility endpoint. It is a passthrough placeholder but should keep a stable JSON shape.


### PR DESCRIPTION
已按维护策略调整：源临时分支被删除后，已将最新提交恢复并固定到 `develop`，并将 `main` 快进到同一提交。

最终提交：`bee763a07a9423dfa2ef4627d125b028e7b436ce`

后续改动统一走 `develop` 分支，不再新建临时功能分支。