### PR TITLE
fix(security): enforce auth token hashing at model layer

### DIFF
--- a/backend/app/model/auth_token.go
+++ b/backend/app/model/auth_token.go
@@ -1,6 +1,9 @@
 package model
 
-import "time"
+import (
+	"rustdesk-api-server-pro/util"
+	"time"
+)
 
 type AuthToken struct {
 	Id         int       `xorm:"'id' int notnull pk autoincr"`
@@ -21,4 +24,22 @@ type AuthToken struct {
 
 func (m *AuthToken) TableName() string {
 	return "auth_token"
+}
+
+func (m *AuthToken) BeforeInsert() {
+	m.normalizeTokenHash()
+}
+
+func (m *AuthToken) BeforeUpdate() {
+	m.normalizeTokenHash()
+}
+
+func (m *AuthToken) normalizeTokenHash() {
+	if m == nil || m.Token == "" {
+		return
+	}
+	if m.TokenHash == "" {
+		m.TokenHash = util.Sha256Hex(m.Token)
+	}
+	m.Token = ""
 }


### PR DESCRIPTION
继续处理安全审计问题：

- 在 AuthToken 模型层新增 BeforeInsert / BeforeUpdate 钩子
- 任何代码路径如果仍写入 Token 明文，入库前自动写入 TokenHash 并清空 Token
- 兜底覆盖 OAuth/OIDC 等遗漏的 token 明文写入点

说明：develop 当前落后 main 的发布前检查提交，但本 PR 只包含 AuthToken 模型层安全修复。